### PR TITLE
add leaveMiddleware feature

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -48,7 +48,11 @@ class FlowContext {
 
   leave () {
     debug('leave')
-    delete this.ctx.session._flow
+    const handler = this.current.leaveMiddleware
+      ? this.current.leaveMiddleware()
+      : this.current.middleware()
+    return handler(this.ctx, () => undefined)
+      .then(() => delete this.ctx.session._flow)
   }
 }
 

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -38,6 +38,10 @@ class Flow extends Composer {
   static enter (...args) {
     return (ctx) => ctx.flow.enter(...args)
   }
+
+  static leave (...args) {
+    return (ctx) => ctx.flow.leave(...args)
+  }
 }
 
 module.exports = Flow

--- a/lib/generic-scene.js
+++ b/lib/generic-scene.js
@@ -4,11 +4,13 @@ class GenericScene extends Composer {
   constructor (id, options) {
     const opts = Object.assign({
       handlers: [],
-      enterHandlers: []
+      enterHandlers: [],
+      leaveHandlers: []
     }, options)
     super(...opts.handlers)
     this.id = id
     this.enterHandler = compose(opts.enterHandlers)
+    this.leaveHandler = compose(opts.leaveHandlers)
   }
 
   enter (...fns) {
@@ -16,8 +18,17 @@ class GenericScene extends Composer {
     return this
   }
 
+  leave (...fns) {
+    this.leaveHandler = compose([this.leaveHandler, ...fns])
+    return this
+  }
+
   enterMiddleware () {
     return this.enterHandler
+  }
+
+  leaveMiddleware () {
+    return this.leaveHandler
   }
 }
 


### PR DESCRIPTION
it would be useful to have some middleware at the end of scene (similar to the enter of scene)

```
// Echo scene
const echoScene = new Scene('echo')
echoScene.enter((ctx) => ctx.reply('echo scene'))
echoScene.leave((ctx) => ctx.reply('end of echo scene'))
```